### PR TITLE
Adding dxvk-async-2.1-3

### DIFF
--- a/dxvk/async.json
+++ b/dxvk/async.json
@@ -1,5 +1,11 @@
 [
     {
+        "name": "dxvk-async-2.1-3",
+        "title": "2.1-3",
+        "version": "2.1-3-async",
+        "uri": "https://gitlab.com/Ph42oN/dxvk-gplasync/-/blob/main/dxvk-gplasync-2.1-3.tar.gz"
+    },
+    {
         "name": "dxvk-async-2.0",
         "title": "2.0",
         "version": "2.0-async",


### PR DESCRIPTION
dxvk-async-2.1-3 provides considerable performance improvements over Sporif's 2.0 version. Besides it looks like as if Sporif has abandoned the project anyway, so it might make sense to follow Ph42oN from now on.