### PR TITLE
Add Spritz-Wine-TkG 10.6-1

### DIFF
--- a/components.json
+++ b/components.json
@@ -9,6 +9,10 @@
             "title": "Wine-GE-Proton"
         },
         {
+            "name": "spritz-wine-tkg",
+            "title": "Spritz-Wine-TkG"
+        },
+        {
             "name": "soda",
             "title": "Soda"
         },

--- a/wine/spritz-wine-tkg.json
+++ b/wine/spritz-wine-tkg.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "spritz-wine-tkg-10.6",
+        "title": "Spritz-Wine-TkG 10.6-1",
+        "uri": "https://github.com/NelloKudo/WineBuilder/releases/download/spritz-v10.6-1/spritz-wine-tkg-fonts-wow64-10.6-1-x86_64.tar.xz",
+        "files": {
+            "wine": "bin/wine",
+            "wine64": "bin/wine64",
+            "wineserver": "bin/wineserver",
+            "wineboot": "bin/wineboot"
+        }
+    }
+]


### PR DESCRIPTION
[spritz-wine](https://github.com/NelloKudo/WineBuilder/releases/tag/spritz-v10.6-1) fixes a number of GI-specific problems by blocking the first request made by the game. Also fixes the game hanging when you close it.