### PR TITLE
Replace Spritz-Wine-TkG with Spritz-Wine-AAGL-TkG.

### DIFF
--- a/wine/spritz-wine-tkg.json
+++ b/wine/spritz-wine-tkg.json
@@ -1,8 +1,8 @@
 [
     {
-        "name": "spritz-wine-tkg-10.6",
-        "title": "Spritz-Wine-TkG 10.6-1",
-        "uri": "https://github.com/NelloKudo/WineBuilder/releases/download/spritz-v10.6-1/spritz-wine-tkg-fonts-wow64-10.6-1-x86_64.tar.xz",
+        "name": "spritz-wine-aagl-tkg-10.6",
+        "title": "Spritz-Wine-AAGL-TkG 10.6-1",
+        "uri": "https://github.com/NelloKudo/WineBuilder/releases/download/aagl-spritz-v10.6-1/spritz-wine-aagl-tkg-fonts-wow64-10.6-1-x86_64.tar.xz",
         "files": {
             "wine": "bin/wine",
             "wine64": "bin/wine64",


### PR DESCRIPTION
Keeping it simple with plain Wine-TkG + GI patches, for compatibility and future updates.