### PR TITLE
Update Spritz-Wine-TkG to new link

### DIFF
--- a/wine/spritz-wine-tkg.json
+++ b/wine/spritz-wine-tkg.json
@@ -1,11 +1,11 @@
 [
     {
-        "name": "spritz-wine-aagl-tkg-10.6",
+        "name": "wine-spritz-10.6-staging-tkg-aagl-amd64-wow64",
         "title": "Spritz-Wine-AAGL-TkG 10.6-1",
-        "uri": "https://github.com/NelloKudo/WineBuilder/releases/download/aagl-spritz-v10.6-1/spritz-wine-aagl-tkg-fonts-wow64-10.6-1-x86_64.tar.xz",
+        "uri": "https://github.com/NelloKudo/Wine-Builds/releases/download/wine-tkg-aagl-v10.6-1/wine-spritz-10.6-staging-tkg-aagl-amd64-wow64.tar.xz",
         "files": {
             "wine": "bin/wine",
-            "wine64": "bin/wine64",
+            "wine64": "bin/wine",
             "wineserver": "bin/wineserver",
             "wineboot": "bin/wineboot"
         }


### PR DESCRIPTION
Replacing old build with a new one from [my fork of Kron4ek's Wine-Builds](https://github.com/NelloKudo/Wine-Builds), with just the essential changes to apply GI patches. 

Figured this would be the easiest way for devs (and users) to verify what's behind the builds, as well as having all the -TkG builds made from the same script. FYI: it's literally two commits xd

Release link: https://github.com/NelloKudo/Wine-Builds/releases/tag/wine-tkg-aagl-v10.6-1
Again: plain Wine-TkG 10.6 + GI fixes.